### PR TITLE
".section-wrapper" selector removed

### DIFF
--- a/themes/gugg-iis.yaml
+++ b/themes/gugg-iis.yaml
@@ -57,13 +57,12 @@ Gugg iis:
               }
             }
           .section:
-            .section-wrapper:
-              hui-section:
-                hui-grid-section$:
-                  ha-sortable:
-                    .container:
-                      .: |
-                        .container.container {
-                          --column-count: 6;
-                          gap: var(--atc-theme-card-gap, 16px);
-                        }
+            hui-section:
+              hui-grid-section$:
+                ha-sortable:
+                  .container:
+                    .: |
+                      .container.container {
+                        --column-count: 6;
+                        gap: var(--atc-theme-card-gap, 16px);
+                      }


### PR DESCRIPTION
With Home Assistant 2024.06, the class "section-wrapper" is no longer in the DOM. CSS adapted accordingly